### PR TITLE
don't use --no-index during make install

### DIFF
--- a/{{cookiecutter.app_name}}/makefile
+++ b/{{cookiecutter.app_name}}/makefile
@@ -9,7 +9,7 @@ SAGE = sage
 all: install test
 
 install:
-	$(SAGE) -pip install --upgrade --no-index -v .
+	$(SAGE) -pip install --upgrade -v .
 
 uninstall:
 	$(SAGE) -pip uninstall .


### PR DESCRIPTION
The --no-index tells pip that it is not allowed to look on pypi for packages, but this is bad since it doesn't allow for pip to automatically install requirements